### PR TITLE
Add split initial cost support

### DIFF
--- a/app/components/edit_motorbike_dialog.py
+++ b/app/components/edit_motorbike_dialog.py
@@ -40,6 +40,36 @@ def edit_motorbike_dialog() -> rx.Component:
             ),
             rx.el.div(
                 rx.el.label(
+                    "Tanya's Share:",
+                    html_for="edit_motorbike_tanya_initial_cost",
+                ),
+                rx.el.input(
+                    id="edit_motorbike_tanya_initial_cost",
+                    type="number",
+                    step="0.01",
+                    default_value=MotorbikeState.edit_motorbike_form_tanya_initial_cost,
+                    on_change=MotorbikeState.set_edit_motorbike_form_tanya_initial_cost,
+                    class_name="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm",
+                ),
+                class_name="mb-4",
+            ),
+            rx.el.div(
+                rx.el.label(
+                    "Gerald's Share:",
+                    html_for="edit_motorbike_gerald_initial_cost",
+                ),
+                rx.el.input(
+                    id="edit_motorbike_gerald_initial_cost",
+                    type="number",
+                    step="0.01",
+                    default_value=MotorbikeState.edit_motorbike_form_gerald_initial_cost,
+                    on_change=MotorbikeState.set_edit_motorbike_form_gerald_initial_cost,
+                    class_name="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm",
+                ),
+                class_name="mb-4",
+            ),
+            rx.el.div(
+                rx.el.label(
                     "Bought By:",
                     html_for="edit_motorbike_buyer",
                 ),

--- a/app/components/motorbike_form.py
+++ b/app/components/motorbike_form.py
@@ -42,6 +42,40 @@ def motorbike_form() -> rx.Component:
         ),
         rx.el.div(
             rx.el.label(
+                "Tanya's Share:",
+                html_for="motorbike_tanya_initial_cost",
+                class_name="block text-sm font-medium text-gray-700",
+            ),
+            rx.el.input(
+                name="tanya_initial_cost",
+                id="motorbike_tanya_initial_cost",
+                type="number",
+                step="0.01",
+                default_value=MotorbikeState.new_motorbike_tanya_initial_cost,
+                on_change=MotorbikeState.set_new_motorbike_tanya_initial_cost,
+                class_name="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm",
+            ),
+            class_name="mb-4",
+        ),
+        rx.el.div(
+            rx.el.label(
+                "Gerald's Share:",
+                html_for="motorbike_gerald_initial_cost",
+                class_name="block text-sm font-medium text-gray-700",
+            ),
+            rx.el.input(
+                name="gerald_initial_cost",
+                id="motorbike_gerald_initial_cost",
+                type="number",
+                step="0.01",
+                default_value=MotorbikeState.new_motorbike_gerald_initial_cost,
+                on_change=MotorbikeState.set_new_motorbike_gerald_initial_cost,
+                class_name="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm",
+            ),
+            class_name="mb-4",
+        ),
+        rx.el.div(
+            rx.el.label(
                 "Bought By:",
                 html_for="motorbike_buyer",
                 class_name="block text-sm font-medium text-gray-700",

--- a/app/db_setup.py
+++ b/app/db_setup.py
@@ -46,7 +46,10 @@ def populate_example_data():
             )
         else:
             bike1 = MotorbikeDB(
-                name="Honda CB750", initial_cost=2500.0
+                name="Honda CB750",
+                initial_cost=2500.0,
+                tanya_initial_cost=1250.0,
+                gerald_initial_cost=1250.0,
             )
             part1_1 = PartDB(
                 name="Carburetor Kit",
@@ -63,7 +66,10 @@ def populate_example_data():
                 motorbike=bike1,
             )
             bike2 = MotorbikeDB(
-                name="Yamaha XS650", initial_cost=1800.0
+                name="Yamaha XS650",
+                initial_cost=1800.0,
+                tanya_initial_cost=900.0,
+                gerald_initial_cost=900.0,
             )
             part2_1 = PartDB(
                 name="Brake Pads",

--- a/app/models.py
+++ b/app/models.py
@@ -49,6 +49,8 @@ class MotorbikeDB(rx.Model, table=True):
     )
     name: str
     initial_cost: float
+    tanya_initial_cost: float = Field(default=0.0)
+    gerald_initial_cost: float = Field(default=0.0)
     buyer: PyOptional[str] = Field(default=None)
     is_sold: bool = Field(default=False)
     sold_value: PyOptional[float] = Field(default=None)

--- a/app/states/analytics_state.py
+++ b/app/states/analytics_state.py
@@ -50,26 +50,12 @@ class AnalyticsState(rx.State):
         for bike in filtered_bikes:
             if bike["ignore_from_calculations"]:
                 continue
-            tanya_total_investment_on_bike = bike[
-                "tanya_parts_cost"
-            ]
-            gerald_total_investment_on_bike = bike[
-                "gerald_parts_cost"
-            ]
-            if (
-                bike["bike_buyer"]
-                and bike["bike_buyer"].lower() == "tanya"
-            ):
-                tanya_total_investment_on_bike += bike[
-                    "initial_cost"
-                ]
-            elif (
-                bike["bike_buyer"]
-                and bike["bike_buyer"].lower() == "gerald"
-            ):
-                gerald_total_investment_on_bike += bike[
-                    "initial_cost"
-                ]
+            tanya_total_investment_on_bike = (
+                bike["tanya_parts_cost"] + bike["tanya_initial_cost"]
+            )
+            gerald_total_investment_on_bike = (
+                bike["gerald_parts_cost"] + bike["gerald_initial_cost"]
+            )
             profit = None
             tanya_profit_share = None
             gerald_profit_share = None


### PR DESCRIPTION
## Summary
- allow storing Tanya/Gerald contributions for bike purchases
- expose contribution fields in add and edit forms
- compute analytics using split initial costs
- update example data for new fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846ec315f90832c8f17d3facef24593