### PR TITLE
Add unified layout and set home page

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2,9 +2,7 @@ import reflex as rx
 from app.pages.landing_page import landing_page
 from app.pages.dashboard_page import dashboard_page
 from app.pages.motorbikes_page import motorbikes_page
-from app.pages.motorbike_detail_page import (
-    motorbike_detail_page,
-)
+from app.pages.motorbike_detail_page import motorbike_detail_page
 from app.pages.sign_in import sign_in
 from app.pages.sign_up import sign_up
 from app.pages.analytics_page import analytics_page
@@ -25,7 +23,10 @@ app = app_with_theme()
 create_db_and_tables()
 populate_example_data()
 app.add_page(
-    landing_page, route="/", on_load=AuthState.check_session
+    motorbikes_page, route="/", on_load=AuthState.check_session
+)
+app.add_page(
+    landing_page, route="/landing", on_load=AuthState.check_session
 )
 app.add_page(
     dashboard_page,

--- a/app/components/layout.py
+++ b/app/components/layout.py
@@ -1,0 +1,54 @@
+import reflex as rx
+from app.states.auth_state import AuthState
+
+
+def page_layout(page_title: str, content: rx.Component, **props) -> rx.Component:
+    return rx.el.div(
+        rx.el.div(
+            rx.el.h1(
+                page_title,
+                class_name="text-3xl font-bold",
+            ),
+            rx.el.div(
+                rx.el.button(
+                    "Sign Out",
+                    on_click=AuthState.sign_out,
+                    class_name="mr-4 py-1 px-3 rounded-md text-sm text-white bg-red-600 hover:bg-red-700",
+                ),
+                rx.image(
+                    src="/favicon.ico",
+                    alt="Company Logo",
+                    class_name="h-10 w-10",
+                ),
+                class_name="flex items-center ml-auto",
+            ),
+            class_name="flex items-center justify-between px-4 py-2 bg-gray-200",
+        ),
+        rx.el.nav(
+            rx.hstack(
+                rx.link(
+                    "All Motorbikes",
+                    href="/",
+                    class_name="px-3 py-2 text-blue-600 hover:text-blue-800",
+                ),
+                rx.link(
+                    "Dashboard",
+                    href="/dashboard",
+                    class_name="px-3 py-2 text-indigo-600 hover:text-indigo-800",
+                ),
+                rx.link(
+                    "Analytics",
+                    href="/analytics",
+                    class_name="px-3 py-2 text-purple-600 hover:text-purple-800",
+                ),
+                class_name="space-x-4",
+            ),
+            class_name="bg-gray-300 px-4 py-2",
+        ),
+        rx.el.div(
+            content,
+            class_name="p-4",
+        ),
+        class_name="min-h-screen bg-gray-100 font-sans",
+        **props,
+    )

--- a/app/pages/analytics_page.py
+++ b/app/pages/analytics_page.py
@@ -80,151 +80,145 @@ def render_analytics_row(
 
 def analytics_page() -> rx.Component:
     content = rx.fragment(
-            rx.el.h2(
-                "Overall Summary",
-                class_name="text-2xl font-semibold text-gray-700 mb-4",
+        rx.el.h2(
+            "Overall Summary",
+            class_name="text-2xl font-semibold text-gray-700 mb-4",
+        ),
+        rx.el.div(
+            rx.el.label(
+                "Filter by Sold Status:",
+                class_name="mr-2 font-medium text-gray-700",
+            ),
+            rx.el.select(
+                rx.el.option("Show All Bikes", value="all"),
+                rx.el.option("Show Sold Bikes Only", value="sold"),
+                rx.el.option(
+                    "Show Unsold Bikes Only",
+                    value="unsold",
+                ),
+                value=AnalyticsState.filter_sold_status,
+                on_change=AnalyticsState.set_filter_sold_status,
+                class_name="mb-6 p-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500",
+            ),
+            class_name="mb-6 flex items-center",
+        ),
+        rx.el.div(
+            rx.el.div(
+                rx.el.p(
+                    "Total Tanya's Investment:",
+                    class_name="text-sm font-medium text-gray-500",
+                ),
+                rx.el.p(
+                    f"${AnalyticsState.overall_summary['total_tanya_investment']:.2f}",
+                    class_name="mt-1 text-xl font-semibold text-blue-600",
+                ),
+                class_name="bg-white shadow rounded-lg p-4",
             ),
             rx.el.div(
-                rx.el.label(
-                    "Filter by Sold Status:",
-                    class_name="mr-2 font-medium text-gray-700",
+                rx.el.p(
+                    "Total Gerald's Investment:",
+                    class_name="text-sm font-medium text-gray-500",
                 ),
-                rx.el.select(
-                    rx.el.option(
-                        "Show All Bikes", value="all"
-                    ),
-                    rx.el.option(
-                        "Show Sold Bikes Only", value="sold"
-                    ),
-                    rx.el.option(
-                        "Show Unsold Bikes Only",
-                        value="unsold",
-                    ),
-                    value=AnalyticsState.filter_sold_status,
-                    on_change=AnalyticsState.set_filter_sold_status,
-                    class_name="mb-6 p-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500",
+                rx.el.p(
+                    f"${AnalyticsState.overall_summary['total_gerald_investment']:.2f}",
+                    class_name="mt-1 text-xl font-semibold text-green-600",
                 ),
-                class_name="mb-6 flex items-center",
+                class_name="bg-white shadow rounded-lg p-4",
             ),
             rx.el.div(
-                rx.el.div(
-                    rx.el.p(
-                        "Total Tanya's Investment:",
-                        class_name="text-sm font-medium text-gray-500",
-                    ),
-                    rx.el.p(
-                        f"${AnalyticsState.overall_summary['total_tanya_investment']:.2f}",
-                        class_name="mt-1 text-xl font-semibold text-blue-600",
-                    ),
-                    class_name="bg-white shadow rounded-lg p-4",
+                rx.el.p(
+                    "Total Tanya's Profit Share:",
+                    class_name="text-sm font-medium text-gray-500",
                 ),
-                rx.el.div(
-                    rx.el.p(
-                        "Total Gerald's Investment:",
-                        class_name="text-sm font-medium text-gray-500",
-                    ),
-                    rx.el.p(
-                        f"${AnalyticsState.overall_summary['total_gerald_investment']:.2f}",
-                        class_name="mt-1 text-xl font-semibold text-green-600",
-                    ),
-                    class_name="bg-white shadow rounded-lg p-4",
+                rx.el.p(
+                    f"${AnalyticsState.overall_summary['total_tanya_profit_share']:.2f}",
+                    class_name="mt-1 text-xl font-semibold text-blue-600",
                 ),
-                rx.el.div(
-                    rx.el.p(
-                        "Total Tanya's Profit Share:",
-                        class_name="text-sm font-medium text-gray-500",
-                    ),
-                    rx.el.p(
-                        f"${AnalyticsState.overall_summary['total_tanya_profit_share']:.2f}",
-                        class_name="mt-1 text-xl font-semibold text-blue-600",
-                    ),
-                    class_name="bg-white shadow rounded-lg p-4",
-                ),
-                rx.el.div(
-                    rx.el.p(
-                        "Total Gerald's Profit Share:",
-                        class_name="text-sm font-medium text-gray-500",
-                    ),
-                    rx.el.p(
-                        f"${AnalyticsState.overall_summary['total_gerald_profit_share']:.2f}",
-                        class_name="mt-1 text-xl font-semibold text-green-600",
-                    ),
-                    class_name="bg-white shadow rounded-lg p-4",
-                ),
-                class_name="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8",
-            ),
-            rx.el.h2(
-                "Bike Breakdown",
-                class_name="text-2xl font-semibold text-gray-700 mb-4",
+                class_name="bg-white shadow rounded-lg p-4",
             ),
             rx.el.div(
-                rx.el.table(
-                    rx.el.thead(
+                rx.el.p(
+                    "Total Gerald's Profit Share:",
+                    class_name="text-sm font-medium text-gray-500",
+                ),
+                rx.el.p(
+                    f"${AnalyticsState.overall_summary['total_gerald_profit_share']:.2f}",
+                    class_name="mt-1 text-xl font-semibold text-green-600",
+                ),
+                class_name="bg-white shadow rounded-lg p-4",
+            ),
+            class_name="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8",
+        ),
+        rx.el.h2(
+            "Bike Breakdown",
+            class_name="text-2xl font-semibold text-gray-700 mb-4",
+        ),
+        rx.el.div(
+            rx.el.table(
+                rx.el.thead(
+                    rx.el.tr(
+                        rx.el.th(
+                            "Bike Name",
+                            class_name="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider",
+                        ),
+                        rx.el.th(
+                            "Initial Cost",
+                            class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
+                        ),
+                        rx.el.th(
+                            "Bike Buyer",
+                            class_name="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider",
+                        ),
+                        rx.el.th(
+                            "Total Cost (Bike + Parts)",
+                            class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
+                        ),
+                        rx.el.th(
+                            "Tanya's Inv. (Bike + Parts)",
+                            class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
+                        ),
+                        rx.el.th(
+                            "Gerald's Inv. (Bike + Parts)",
+                            class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
+                        ),
+                        rx.el.th(
+                            "Profit",
+                            class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
+                        ),
+                        rx.el.th(
+                            "Tanya's Share",
+                            class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
+                        ),
+                        rx.el.th(
+                            "Gerald's Share",
+                            class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
+                        ),
+                        rx.el.th(
+                            "Sold",
+                            class_name="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider",
+                        ),
+                    )
+                ),
+                rx.el.tbody(
+                    rx.foreach(
+                        AnalyticsState.bike_analytics_data,
+                        render_analytics_row,
+                    ),
+                    rx.cond(
+                        AnalyticsState.bike_analytics_data.length() == 0,
                         rx.el.tr(
-                            rx.el.th(
-                                "Bike Name",
-                                class_name="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider",
-                            ),
-                            rx.el.th(
-                                "Initial Cost",
-                                class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
-                            ),
-                            rx.el.th(
-                                "Bike Buyer",
-                                class_name="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider",
-                            ),
-                            rx.el.th(
-                                "Total Cost (Bike + Parts)",
-                                class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
-                            ),
-                            rx.el.th(
-                                "Tanya's Inv. (Bike + Parts)",
-                                class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
-                            ),
-                            rx.el.th(
-                                "Gerald's Inv. (Bike + Parts)",
-                                class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
-                            ),
-                            rx.el.th(
-                                "Profit",
-                                class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
-                            ),
-                            rx.el.th(
-                                "Tanya's Share",
-                                class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
-                            ),
-                            rx.el.th(
-                                "Gerald's Share",
-                                class_name="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider",
-                            ),
-                            rx.el.th(
-                                "Sold",
-                                class_name="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider",
-                            ),
-                        )
-                    ),
-                    rx.el.tbody(
-                        rx.foreach(
-                            AnalyticsState.bike_analytics_data,
-                            render_analytics_row,
+                            rx.el.td(
+                                "No motorbike data available for the selected filter.",
+                                col_span=10,
+                                class_name="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center",
+                            )
                         ),
-                        rx.cond(
-                            AnalyticsState.bike_analytics_data.length()
-                            == 0,
-                            rx.el.tr(
-                                rx.el.td(
-                                    "No motorbike data available for the selected filter.",
-                                    col_span=10,
-                                    class_name="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center",
-                                )
-                            ),
-                            rx.fragment(),
-                        ),
+                        rx.fragment(),
                     ),
-                    class_name="min-w-full divide-y divide-gray-200 shadow border-b border-gray-200 sm:rounded-lg",
                 ),
-                class_name="overflow-x-auto",
+                class_name="min-w-full divide-y divide-gray-200 shadow border-b border-gray-200 sm:rounded-lg",
             ),
+            class_name="overflow-x-auto",
         ),
         class_name="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8",
     )

--- a/app/pages/analytics_page.py
+++ b/app/pages/analytics_page.py
@@ -1,10 +1,7 @@
 import reflex as rx
-from app.states.analytics_state import (
-    AnalyticsState,
-    BikeAnalytics,
-)
-from app.states.auth_state import AuthState
+from app.states.analytics_state import AnalyticsState, BikeAnalytics
 from app.states.motorbike_state import MotorbikeState
+from app.components.layout import page_layout
 
 
 def render_analytics_row(
@@ -82,38 +79,7 @@ def render_analytics_row(
 
 
 def analytics_page() -> rx.Component:
-    return rx.el.div(
-        rx.el.div(
-            rx.el.div(
-                rx.el.h1(
-                    "Business Analytics",
-                    class_name="text-3xl font-bold text-gray-800 mb-6",
-                ),
-                rx.el.button(
-                    "Sign Out",
-                    on_click=AuthState.sign_out,
-                    class_name="absolute top-4 right-4 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500",
-                ),
-                class_name="relative",
-            ),
-            rx.el.div(
-                rx.link(
-                    "Back to Landing Page",
-                    href="/",
-                    class_name="text-blue-600 hover:text-blue-800 mr-4",
-                ),
-                rx.link(
-                    "Back to Dashboard",
-                    href="/dashboard",
-                    class_name="text-indigo-600 hover:text-indigo-800 mr-4",
-                ),
-                rx.link(
-                    "View All Motorbikes",
-                    href="/motorbikes",
-                    class_name="text-indigo-600 hover:text-indigo-800",
-                ),
-                class_name="mb-6",
-            ),
+    content = rx.fragment(
             rx.el.h2(
                 "Overall Summary",
                 class_name="text-2xl font-semibold text-gray-700 mb-4",
@@ -260,10 +226,13 @@ def analytics_page() -> rx.Component:
                 class_name="overflow-x-auto",
             ),
         ),
-        class_name="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8 min-h-screen bg-gray-100 py-8 font-sans",
+        class_name="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8",
+    )
+    return page_layout(
+        "Business Analytics",
+        content,
         on_mount=[
             MotorbikeState.load_all_data,
             AnalyticsState.set_filter_sold_status("all"),
-            AuthState.check_session,
         ],
     )

--- a/app/pages/dashboard_page.py
+++ b/app/pages/dashboard_page.py
@@ -1,64 +1,31 @@
 import reflex as rx
 from app.states.motorbike_state import MotorbikeState
-from app.states.auth_state import AuthState
 from app.components.motorbike_form import motorbike_form
 from app.components.part_form import part_form
-from app.components.motorbikes_display import (
-    motorbikes_display,
-)
+from app.components.motorbikes_display import motorbikes_display
 from app.components.summary_display import summary_display
+from app.components.layout import page_layout
 
 
 def dashboard_page() -> rx.Component:
-    return rx.el.div(
+    content = rx.fragment(
         rx.el.div(
             rx.el.div(
-                rx.el.h1(
-                    "Motorbike Cost Tracker Dashboard",
-                    class_name="text-4xl font-bold text-center text-gray-800 mb-2",
-                ),
-                rx.el.button(
-                    "Sign Out",
-                    on_click=AuthState.sign_out,
-                    class_name="absolute top-4 right-4 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500",
-                ),
-                class_name="relative",
+                motorbike_form(),
+                class_name="w-full md:w-1/2 md:pr-4 mb-8 md:mb-0",
             ),
             rx.el.div(
-                rx.link(
-                    "Back to Landing Page",
-                    href="/",
-                    class_name="text-center block text-blue-600 hover:text-blue-800 mb-2",
-                ),
-                rx.link(
-                    "View All Motorbikes",
-                    href="/motorbikes",
-                    class_name="text-center block text-indigo-600 hover:text-indigo-800 mb-2",
-                ),
-                rx.link(
-                    "View Analytics",
-                    href="/analytics",
-                    class_name="text-center block text-green-600 hover:text-green-800 mb-8",
-                ),
+                part_form(),
+                class_name="w-full md:w-1/2 md:pl-4",
             ),
-            rx.el.div(
-                rx.el.div(
-                    motorbike_form(),
-                    class_name="w-full md:w-1/2 md:pr-4 mb-8 md:mb-0",
-                ),
-                rx.el.div(
-                    part_form(),
-                    class_name="w-full md:w-1/2 md:pl-4",
-                ),
-                class_name="md:flex md:space-x-4 mb-8",
-            ),
-            rx.el.div(summary_display(), class_name="my-8"),
-            rx.el.div(motorbikes_display()),
-            class_name="max-w-5xl mx-auto p-4 sm:p-6 lg:p-8",
+            class_name="md:flex md:space-x-4 mb-8",
         ),
-        class_name="min-h-screen bg-gray-100 py-8 font-sans",
-        on_mount=[
-            MotorbikeState.load_all_data,
-            AuthState.check_session,
-        ],
+        rx.el.div(summary_display(), class_name="my-8"),
+        rx.el.div(motorbikes_display()),
+        class_name="max-w-5xl mx-auto p-4 sm:p-6 lg:p-8",
+    )
+    return page_layout(
+        "Motorbike Cost Tracker Dashboard",
+        content,
+        on_mount=[MotorbikeState.load_all_data],
     )

--- a/app/pages/motorbike_detail_page.py
+++ b/app/pages/motorbike_detail_page.py
@@ -1,11 +1,9 @@
 import reflex as rx
 from app.states.motorbike_state import MotorbikeState, Part
-from app.states.auth_state import AuthState
 from app.components.part_form import part_form
-from app.components.edit_motorbike_dialog import (
-    edit_motorbike_dialog,
-)
+from app.components.edit_motorbike_dialog import edit_motorbike_dialog
 from app.components.edit_part_dialog import edit_part_dialog
+from app.components.layout import page_layout
 
 
 def render_detail_part_row(
@@ -264,53 +262,21 @@ def motorbike_detail_content() -> rx.Component:
 
 
 def motorbike_detail_page() -> rx.Component:
-    return rx.el.div(
+    content = rx.fragment(
         edit_motorbike_dialog(),
         edit_part_dialog(),
-        rx.el.div(
-            rx.el.div(
-                rx.el.h1(
-                    "Motorbike Details",
-                    class_name="text-3xl font-bold text-gray-800 mb-6",
-                ),
-                rx.el.button(
-                    "Sign Out",
-                    on_click=AuthState.sign_out,
-                    class_name="absolute top-4 right-4 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500",
-                ),
-                class_name="relative",
-            ),
-            rx.el.div(
-                rx.link(
-                    "Back to Landing Page",
-                    href="/",
-                    class_name="text-blue-600 hover:text-blue-800 mr-4",
-                ),
-                rx.link(
-                    "Back to All Motorbikes",
-                    href="/motorbikes",
-                    class_name="text-indigo-600 hover:text-indigo-800 mr-4",
-                ),
-                rx.link(
-                    "Back to Dashboard",
-                    href="/dashboard",
-                    class_name="text-indigo-600 hover:text-indigo-800",
-                ),
-                class_name="mb-6",
-            ),
-            rx.cond(
-                MotorbikeState.selected_motorbike_for_detail
-                != None,
-                motorbike_detail_content(),
-                rx.el.p(
-                    "Loading motorbike details or motorbike not found...",
-                    class_name="text-gray-500",
-                ),
+        rx.cond(
+            MotorbikeState.selected_motorbike_for_detail != None,
+            motorbike_detail_content(),
+            rx.el.p(
+                "Loading motorbike details or motorbike not found...",
+                class_name="text-gray-500",
             ),
         ),
-        class_name="max-w-4xl mx-auto p-4 sm:p-6 lg:p-8 min-h-screen bg-gray-100 py-8 font-sans",
-        on_mount=[
-            MotorbikeState.load_all_data,
-            AuthState.check_session,
-        ],
+        class_name="max-w-4xl mx-auto p-4 sm:p-6 lg:p-8",
+    )
+    return page_layout(
+        "Motorbike Details",
+        content,
+        on_mount=[MotorbikeState.load_all_data],
     )

--- a/app/pages/motorbikes_page.py
+++ b/app/pages/motorbikes_page.py
@@ -1,64 +1,32 @@
 import reflex as rx
 from app.states.motorbike_state import MotorbikeState
-from app.states.auth_state import AuthState
-from app.components.motorbikes_list_item import (
-    motorbikes_list_item,
-)
-from app.components.edit_motorbike_dialog import (
-    edit_motorbike_dialog,
-)
+from app.components.motorbikes_list_item import motorbikes_list_item
+from app.components.edit_motorbike_dialog import edit_motorbike_dialog
 from app.components.edit_part_dialog import edit_part_dialog
+from app.components.layout import page_layout
 
 
 def motorbikes_page() -> rx.Component:
-    return rx.el.div(
+    content = rx.fragment(
         edit_motorbike_dialog(),
         edit_part_dialog(),
-        rx.el.div(
-            rx.el.div(
-                rx.el.h1(
-                    "All Motorbikes",
-                    class_name="text-3xl font-bold text-gray-800 mb-6",
-                ),
-                rx.el.button(
-                    "Sign Out",
-                    on_click=AuthState.sign_out,
-                    class_name="absolute top-4 right-4 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500",
-                ),
-                class_name="relative",
+        rx.cond(
+            MotorbikeState.sorted_motorbikes_for_display.length() == 0,
+            rx.el.p(
+                "No motorbikes have been added yet. Go to the dashboard to add one.",
+                class_name="text-gray-600 text-center py-10",
             ),
             rx.el.div(
-                rx.link(
-                    "Back to Landing Page",
-                    href="/",
-                    class_name="text-blue-600 hover:text-blue-800 mr-4",
+                rx.foreach(
+                    MotorbikeState.sorted_motorbikes_for_display,
+                    motorbikes_list_item,
                 ),
-                rx.link(
-                    "Back to Dashboard",
-                    href="/dashboard",
-                    class_name="text-indigo-600 hover:text-indigo-800",
-                ),
-                class_name="mb-6",
-            ),
-            rx.cond(
-                MotorbikeState.sorted_motorbikes_for_display.length()
-                == 0,
-                rx.el.p(
-                    "No motorbikes have been added yet. Go to the dashboard to add one.",
-                    class_name="text-gray-600 text-center py-10",
-                ),
-                rx.el.div(
-                    rx.foreach(
-                        MotorbikeState.sorted_motorbikes_for_display,
-                        motorbikes_list_item,
-                    ),
-                    class_name="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6",
-                ),
+                class_name="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6",
             ),
         ),
-        class_name="max-w-6xl mx-auto p-4 sm:p-6 lg:p-8 min-h-screen bg-gray-100 py-8 font-sans",
-        on_mount=[
-            MotorbikeState.load_all_data,
-            AuthState.check_session,
-        ],
+    )
+    return page_layout(
+        "All Motorbikes",
+        content,
+        on_mount=[MotorbikeState.load_all_data],
     )


### PR DESCRIPTION
## Summary
- implement a reusable `page_layout` component
- update motorbike-related pages to use the new layout
- configure `/` route to show All Motorbikes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ee68fa80832c99b8306468c4d75a